### PR TITLE
Remove the "space" which breaks the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 docker run -d \
   --cap-add MKNOD \
   --cap-add NET_ADMIN \
-  --cap-add NET_RAW \ 
+  --cap-add NET_RAW \
   --publish 51820:51820/udp \
   --volume /etc/wireguard:/etc/wireguard \
   ntkme/boringtun


### PR DESCRIPTION
The command in README.md is broken due to an extra space character. This PR removes it.